### PR TITLE
Customization key and level names

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,24 @@ java.util.logging.ConsoleHandler.formatter=io.github.devatherock.json.formatter.
 The path to the logging.properties file can also be passed as JVM arg 
 like `-Djava.util.logging.config.file=/path/to/logging.properties`
 
+## Change key names
+
+You can change the key names using the configuration file `logging.properties`  
+The following is an example with the default key names:
+
+```properties
+io.github.devatherock.json.formatter.JSONFormatter.key_timestamp=@timestamp
+io.github.devatherock.json.formatter.JSONFormatter.key_logger_name=logger_name
+io.github.devatherock.json.formatter.JSONFormatter.key_log_level=level
+io.github.devatherock.json.formatter.JSONFormatter.key_thread_name=thread_name
+io.github.devatherock.json.formatter.JSONFormatter.key_logger_class=class
+io.github.devatherock.json.formatter.JSONFormatter.key_logger_method=method
+io.github.devatherock.json.formatter.JSONFormatter.key_message=message
+io.github.devatherock.json.formatter.JSONFormatter.key_exception=exception
+```
+
 ## Samples
+
 Each line in the generated log will be a JSON. Sample one line message:
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -38,6 +38,27 @@ io.github.devatherock.json.formatter.JSONFormatter.key_message=message
 io.github.devatherock.json.formatter.JSONFormatter.key_exception=exception
 ```
 
+## Use slf4j log level names
+
+
+Change the log level names using the same mapping as [SLF4JBridgeHandler](http://www.slf4j.org/apidocs/org/slf4j/bridge/SLF4JBridgeHandler.html):
+
+```
+FINEST  -> TRACE
+FINER   -> DEBUG
+FINE    -> DEBUG
+INFO    -> INFO
+CONFIG  -> CONFIG
+WARNING -> WARN
+SEVERE  -> ERROR
+```
+
+Set the following in the `logging.properties` file to change the log level names:
+
+```properties
+io.github.devatherock.json.formatter.JSONFormatter.use_slf4j_level_names=true
+```
+
 ## Samples
 
 Each line in the generated log will be a JSON. Sample one line message:

--- a/src/main/java/io/github/devatherock/json/formatter/JSONFormatter.java
+++ b/src/main/java/io/github/devatherock/json/formatter/JSONFormatter.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.logging.Formatter;
 import java.util.logging.Level;
+import java.util.logging.LogManager;
 import java.util.logging.LogRecord;
 import java.util.logging.Logger;
 
@@ -56,6 +57,50 @@ public class JSONFormatter extends Formatter {
 			return (size() > THREAD_NAME_CACHE_SIZE);
 		}
 	};
+
+	public JSONFormatter() {
+		configure();
+	}
+
+	/**
+	 * Configure a {@link JSONFormatter} from LogManager properties.
+	 */
+	private void configure() {
+		LogManager manager = LogManager.getLogManager();
+		String cname = getClass().getName();
+		String value = manager.getProperty(cname + ".key_timestamp");
+		if (value != null) {
+			Constants.KEY_TIMESTAMP = value;
+		}
+		value = manager.getProperty(cname + ".key_logger_name");
+		if (value != null) {
+			Constants.KEY_LOGGER_NAME = value;
+		}
+		value = manager.getProperty(cname + ".key_log_level");
+		if (value != null) {
+			Constants.KEY_LOG_LEVEL = value;
+		}
+		value = manager.getProperty(cname + ".key_thread_name");
+		if (value != null) {
+			Constants.KEY_THREAD_NAME = value;
+		}
+		value = manager.getProperty(cname + ".key_logger_class");
+		if (value != null) {
+			Constants.KEY_LOGGER_CLASS = value;
+		}
+		value = manager.getProperty(cname + ".key_logger_method");
+		if (value != null) {
+			Constants.KEY_LOGGER_METHOD = value;
+		}
+		value = manager.getProperty(cname + ".key_message");
+		if (value != null) {
+			Constants.KEY_MESSAGE = value;
+		}
+		value = manager.getProperty(cname + ".key_exception");
+		if (value != null) {
+			Constants.KEY_EXCEPTION = value;
+		}
+	}
 
 	@Override
 	public String format(LogRecord record) {

--- a/src/main/java/io/github/devatherock/json/formatter/helpers/Constants.java
+++ b/src/main/java/io/github/devatherock/json/formatter/helpers/Constants.java
@@ -24,42 +24,42 @@ public class Constants {
 	/**
 	 * JSON key for log time
 	 */
-	public static final String KEY_TIMESTAMP = "@timestamp";
+	public static String KEY_TIMESTAMP = "@timestamp";
 
 	/**
 	 * JSON key for logger name
 	 */
-	public static final String KEY_LOGGER_NAME = "logger_name";
+	public static String KEY_LOGGER_NAME = "logger_name";
 
 	/**
 	 * JSON key for log level
 	 */
-	public static final String KEY_LOG_LEVEL = "level";
+	public static String KEY_LOG_LEVEL = "level";
 
 	/**
 	 * JSON key for thread name that issued the log statement
 	 */
-	public static final String KEY_THREAD_NAME = "thread_name";
+	public static String KEY_THREAD_NAME = "thread_name";
 
 	/**
 	 * JSON key for class name that issued the log statement
 	 */
-	public static final String KEY_LOGGER_CLASS = "class";
+	public static String KEY_LOGGER_CLASS = "class";
 
 	/**
 	 * JSON key for method name that issued the log statement
 	 */
-	public static final String KEY_LOGGER_METHOD = "method";
+	public static  String KEY_LOGGER_METHOD = "method";
 
 	/**
 	 * JSON key for the message being logged
 	 */
-	public static final String KEY_MESSAGE = "message";
+	public static  String KEY_MESSAGE = "message";
 
 	/**
 	 * JSON key for the exception being logged
 	 */
-	public static final String KEY_EXCEPTION = "exception";
+	public static  String KEY_EXCEPTION = "exception";
 
 	/**
 	 * JSON keys used for fields within the exception object

--- a/src/test/java/io/github/devatherock/json/formatter/helpers/CustomJsonConverterTest.java
+++ b/src/test/java/io/github/devatherock/json/formatter/helpers/CustomJsonConverterTest.java
@@ -14,7 +14,6 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import io.github.devatherock.json.formatter.helpers.Constants;
 import io.github.devatherock.json.formatter.helpers.Constants.ExceptionKeys;
 import io.github.devatherock.json.formatter.testhelpers.TestUtil;
 

--- a/src/test/resources/logging.properties
+++ b/src/test/resources/logging.properties
@@ -3,6 +3,9 @@ handlers=java.util.logging.ConsoleHandler
 java.util.logging.ConsoleHandler.level=INFO
 java.util.logging.ConsoleHandler.formatter=io.github.devatherock.json.formatter.JSONFormatter
 
+# Use slf4j log level names
+#io.github.devatherock.json.formatter.JSONFormatter.use_slf4j_level_names=true
+
 # Change key names
 #io.github.devatherock.json.formatter.JSONFormatter.key_timestamp=@timestamp
 #io.github.devatherock.json.formatter.JSONFormatter.key_logger_name=logger_name

--- a/src/test/resources/logging.properties
+++ b/src/test/resources/logging.properties
@@ -2,3 +2,13 @@ handlers=java.util.logging.ConsoleHandler
 
 java.util.logging.ConsoleHandler.level=INFO
 java.util.logging.ConsoleHandler.formatter=io.github.devatherock.json.formatter.JSONFormatter
+
+# Change key names
+#io.github.devatherock.json.formatter.JSONFormatter.key_timestamp=@timestamp
+#io.github.devatherock.json.formatter.JSONFormatter.key_logger_name=logger_name
+#io.github.devatherock.json.formatter.JSONFormatter.key_log_level=level
+#io.github.devatherock.json.formatter.JSONFormatter.key_thread_name=thread_name
+#io.github.devatherock.json.formatter.JSONFormatter.key_logger_class=class
+#io.github.devatherock.json.formatter.JSONFormatter.key_logger_method=method
+#io.github.devatherock.json.formatter.JSONFormatter.key_message=message
+#io.github.devatherock.json.formatter.JSONFormatter.key_exception=exception


### PR DESCRIPTION
This PR makes it possible to make Tomcat logs and application logs to be consistent. This makes it easier to filter logs when using log searching applications like Kibana.   

For example, when using `slf4j` with `logstash-logback-encoder` (which logs in JSON) you can now change the log level names for Tomcat to look like the names from slf4j. For example, `SEVERE` -> `ERROR`.  

I also added the possibility to change the main key names. For example `thread_name` -> `thread` because I am using custom key names in my applications.  

I added the following to the `README.md`
## Change key names

You can change the key names using the configuration file `logging.properties`  
The following is an example with the default key names:

```properties
io.github.devatherock.json.formatter.JSONFormatter.key_timestamp=@timestamp
io.github.devatherock.json.formatter.JSONFormatter.key_logger_name=logger_name
io.github.devatherock.json.formatter.JSONFormatter.key_log_level=level
io.github.devatherock.json.formatter.JSONFormatter.key_thread_name=thread_name
io.github.devatherock.json.formatter.JSONFormatter.key_logger_class=class
io.github.devatherock.json.formatter.JSONFormatter.key_logger_method=method
io.github.devatherock.json.formatter.JSONFormatter.key_message=message
io.github.devatherock.json.formatter.JSONFormatter.key_exception=exception
```

## Use slf4j log level names


Change the log level names using the same mapping as [SLF4JBridgeHandler](http://www.slf4j.org/apidocs/org/slf4j/bridge/SLF4JBridgeHandler.html):

```
FINEST  -> TRACE
FINER   -> DEBUG
FINE    -> DEBUG
INFO    -> INFO
CONFIG  -> CONFIG
WARNING -> WARN
SEVERE  -> ERROR
```

Set the following in the `logging.properties` file to change the log level names:

```properties
io.github.devatherock.json.formatter.JSONFormatter.use_slf4j_level_names=true
```

